### PR TITLE
Record state of variables mapped to time

### DIFF
--- a/pycrunch/api/serializers.py
+++ b/pycrunch/api/serializers.py
@@ -56,6 +56,7 @@ class CoverageRun:
             files=files_,
             status=self.execution_result.status,
             captured_output=self.execution_result.captured_output,
+            variables_state=self.execution_result.state_timeline.as_json(),
         )
 
 

--- a/pycrunch/discovery/simple.py
+++ b/pycrunch/discovery/simple.py
@@ -137,7 +137,9 @@ class SimpleTestDiscovery:
         for v in all_variables:
             function_or_variable_or_class = getattr(module, v)
             is_class = inspect.isclass(function_or_variable_or_class)
-            if is_class and issubclass(function_or_variable_or_class, sys.modules["unittest"].TestCase):
+            is_unit_test_sub = self.is_subclass_of_unittest(function_or_variable_or_class)
+
+            if is_class and is_unit_test_sub:
                 # print(f'{v} : {function_or_variable_or_class} issubclass of unittest')
                 attr = getattr(function_or_variable_or_class, "__test__", True)
                 # print(attr)
@@ -152,6 +154,10 @@ class SimpleTestDiscovery:
                     found_methods.append(v)
         return found_methods
 
+    def is_subclass_of_unittest(self, function_or_variable_or_class):
+        may_be_not_loaded = sys.modules.get("unittest")
+        is_unit_test_sub = may_be_not_loaded and issubclass(function_or_variable_or_class, may_be_not_loaded.TestCase)
+        return is_unit_test_sub
 
     def is_module_with_tests(self, module_name):
         module_short_name = module_name.split('.')[-1]

--- a/pycrunch/discovery/simple.py
+++ b/pycrunch/discovery/simple.py
@@ -136,10 +136,8 @@ class SimpleTestDiscovery:
         found_methods = []
         for v in all_variables:
             function_or_variable_or_class = getattr(module, v)
-            is_class = inspect.isclass(function_or_variable_or_class)
-            is_unit_test_sub = self.is_subclass_of_unittest(function_or_variable_or_class)
 
-            if is_class and is_unit_test_sub:
+            if self.is_subclass_of_unittest(function_or_variable_or_class):
                 # print(f'{v} : {function_or_variable_or_class} issubclass of unittest')
                 attr = getattr(function_or_variable_or_class, "__test__", True)
                 # print(attr)
@@ -155,6 +153,10 @@ class SimpleTestDiscovery:
         return found_methods
 
     def is_subclass_of_unittest(self, function_or_variable_or_class):
+        is_class = inspect.isclass(function_or_variable_or_class)
+        if not is_class:
+            return False
+
         may_be_not_loaded = sys.modules.get("unittest")
         is_unit_test_sub = may_be_not_loaded and issubclass(function_or_variable_or_class, may_be_not_loaded.TestCase)
         return is_unit_test_sub

--- a/pycrunch/insights/__init__.py
+++ b/pycrunch/insights/__init__.py
@@ -1,0 +1,3 @@
+from pycrunch.insights.variables_inspection import trace
+
+trace = trace

--- a/pycrunch/insights/variables_inspection.py
+++ b/pycrunch/insights/variables_inspection.py
@@ -58,5 +58,5 @@ class InsightTimeline:
         # print(vars())
         ts = clock.now()
         for key, value in kwargs.items():
-            print(key + ' - ' + str(value))
+            # print(key + ' - ' + str(value))
             self.variables.append(RecordedVariable(key, value, ts))

--- a/pycrunch/insights/variables_inspection.py
+++ b/pycrunch/insights/variables_inspection.py
@@ -1,0 +1,62 @@
+from typing import List, Any
+from pycrunch.introspection.clock import clock
+
+timeline = None
+
+def trace(**kwargs):
+    global timeline
+    # todo: do not override, existing, create a list of subscribers
+    if not timeline:
+        # print('trace called, but no timeline injected: ', kwargs)
+        return
+
+    # todo: check for accepted types: str, int, dict() ?
+    timeline.record(**kwargs)
+
+def inject_timeline(new_timeline):
+    global timeline
+    # print(timeline)
+    timeline = new_timeline
+    # print(timeline)
+
+
+class RecordedVariable:
+    def __init__(self, name, value, timestamp):
+        self.name = name
+        self.value = value
+        self.timestamp = timestamp
+
+    def as_json(self):
+        return dict(
+            ts=self.timestamp,
+            name=self.name,
+            value=self.value,
+        )
+
+class InsightTimeline:
+    # Timeline must be viewed as chrome performance timeline or jetbrains timeline profiler UI
+    # Timeline represents state of application on each line (ideally)
+    # currently - on each call of trace function
+    variables: List[RecordedVariable]
+
+    def __init__(self):
+        self.variables = []
+        self.start_timestamp = None
+        pass
+
+    def start(self):
+        self.start_timestamp = clock.now()
+
+    def as_json(self):
+        results = []
+        for v in self.variables:
+            results.append(v.as_json())
+        return results
+
+    def record(self, **kwargs):
+        # print(kwargs)
+        # print(vars())
+        ts = clock.now()
+        for key, value in kwargs.items():
+            print(key + ' - ' + str(value))
+            self.variables.append(RecordedVariable(key, value, ts))

--- a/pycrunch/insights/variables_inspection.py
+++ b/pycrunch/insights/variables_inspection.py
@@ -15,6 +15,7 @@ def trace(**kwargs):
 def inject_timeline(new_timeline):
     global timeline
     # print(timeline)
+
     timeline = new_timeline
     # print(timeline)
 
@@ -64,3 +65,14 @@ class InsightTimeline:
 
     def adjust_to_timeline_start(self, ts):
         return ts - self.start_timestamp
+
+    def make_safe_for_pickle(self):
+        # this is last resort call,
+        # consider avoiding it in first place to not lose performance
+        import pickle
+        for variable in self.variables:
+            try:
+                pickle.dumps(variable)
+            except Exception as e:
+                variable.value = \
+                    f'This cannot be traced: {str(variable.value)}\n\nConsider removing this trace call for faster test execution.'

--- a/pycrunch/insights/variables_inspection.py
+++ b/pycrunch/insights/variables_inspection.py
@@ -1,5 +1,4 @@
 from typing import List, Any
-from pycrunch.introspection.clock import clock
 
 timeline = None
 
@@ -39,13 +38,14 @@ class InsightTimeline:
     # currently - on each call of trace function
     variables: List[RecordedVariable]
 
-    def __init__(self):
+    def __init__(self, clock):
         self.variables = []
         self.start_timestamp = None
+        self.clock = clock
         pass
 
     def start(self):
-        self.start_timestamp = clock.now()
+        self.start_timestamp = self.clock.now()
 
     def as_json(self):
         results = []
@@ -56,7 +56,11 @@ class InsightTimeline:
     def record(self, **kwargs):
         # print(kwargs)
         # print(vars())
-        ts = clock.now()
+        ts = self.clock.now()
+        adjusted_time = self.adjust_to_timeline_start(ts)
         for key, value in kwargs.items():
             # print(key + ' - ' + str(value))
-            self.variables.append(RecordedVariable(key, value, ts))
+            self.variables.append(RecordedVariable(key, value, adjusted_time))
+
+    def adjust_to_timeline_start(self, ts):
+        return ts - self.start_timestamp

--- a/pycrunch/runner/execution_result.py
+++ b/pycrunch/runner/execution_result.py
@@ -14,6 +14,7 @@ class ExecutionResult:
         self.captured_output = None
         self.status = 'pending'
         self.intercepted_exception = None
+        self.state_timeline = None
 
     def record_exception(self, etype, value, current_traceback):
         self.intercepted_exception = ErrorRecord(etype=etype, value=value, current_traceback=current_traceback)
@@ -29,3 +30,6 @@ class ExecutionResult:
 
     def output_did_become_available(self, captured_output):
         self.captured_output = captured_output
+
+    def state_timeline_did_become_available(self, state_timeline):
+        self.state_timeline = state_timeline

--- a/pycrunch/runner/test_runner.py
+++ b/pycrunch/runner/test_runner.py
@@ -6,6 +6,7 @@ import coverage
 
 # logger = logging.getLogger(__name__)
 from pycrunch.insights.variables_inspection import InsightTimeline, inject_timeline
+from pycrunch.introspection.clock import clock
 
 DISABLE_COVERAGE = False
 
@@ -28,7 +29,7 @@ class TestRunner():
             self.timeline.begin_nested_interval(f'Running test {test_to_run.get("fqn", "unknown")}')
 
             # record traced variables
-            state_timeline = InsightTimeline()
+            state_timeline = InsightTimeline(clock=clock)
             state_timeline.start()
             inject_timeline(state_timeline)
 

--- a/pycrunch/runner/test_runner.py
+++ b/pycrunch/runner/test_runner.py
@@ -5,7 +5,7 @@ import coverage
 
 
 # logger = logging.getLogger(__name__)
-
+from pycrunch.insights.variables_inspection import InsightTimeline, inject_timeline
 
 DISABLE_COVERAGE = False
 
@@ -26,8 +26,13 @@ class TestRunner():
         results = dict()
         for test_to_run in tests:
             self.timeline.begin_nested_interval(f'Running test {test_to_run.get("fqn", "unknown")}')
+
+            # record traced variables
+            state_timeline = InsightTimeline()
+            state_timeline.start()
+            inject_timeline(state_timeline)
+
             cov = self.start_coverage()
-            self.timeline.mark_event('Run: Coverage started')
 
             try:
                 with capture_stdout() as get_value:
@@ -48,6 +53,8 @@ class TestRunner():
                     self.timeline.mark_event('Received captured output')
 
                     execution_result.output_did_become_available(captured_output)
+                    execution_result.state_timeline_did_become_available(state_timeline)
+
                     self.timeline.mark_event('Before coverage serialization')
                     coverage_for_run = serialize_test_run(cov, fqn, time_elapsed, test_metadata=test_to_run, execution_result=execution_result)
                     self.timeline.mark_event('After coverage serialization')
@@ -74,5 +81,6 @@ class TestRunner():
         # cov.exclude('def')
 
         # logger.debug('-- after coverage.start')
+        self.timeline.mark_event('Run: Coverage started')
         return cov
 

--- a/pycrunch/tests/test_insights.py
+++ b/pycrunch/tests/test_insights.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
-from pycrunch.insights.variables_inspection import trace, InsightTimeline, inject_timeline
+from pycrunch.insights.variables_inspection import InsightTimeline, inject_timeline
+from pycrunch.insights import trace
 from pycrunch.introspection.clock import clock
 
 

--- a/pycrunch/tests/test_insights.py
+++ b/pycrunch/tests/test_insights.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 from pycrunch.insights.variables_inspection import trace, InsightTimeline, inject_timeline
+from pycrunch.introspection.clock import clock
 
 
 def test_should_trace_something_to_timeline():
@@ -20,12 +21,13 @@ def test_marker_single_variable_trace():
     trace(value_a=1)
     marker('point_of_interest')
     trace(value_a=42)
+    trace(value_b='after sleep')
 
 def test_marker_multiple_variables_trace():
     for i in range(10):
         trace(loop_counter=i)
 
-    trace(value_a=1)
+    trace(value_a=__name__)
     marker('point_of_interest')
     trace(value_a=42)
     some_local = dict(
@@ -49,7 +51,8 @@ def test_inject_timeline_and_call_it_on_trace():
 
 def test_timeline_one_variable():
     variable_name = 42
-    x = InsightTimeline()
+    x = InsightTimeline(clock)
+    x.start()
 
     x.record(variable_name=42)
 
@@ -61,8 +64,8 @@ def test_timeline_one_variable():
 def test_timeline_two_variables():
     variable_a = 42
     variable_b = 'Bret Victor'
-    x = InsightTimeline()
-
+    x = InsightTimeline(clock)
+    x.start()
     x.record(variable_a=variable_a, brightest_mind=variable_b)
 
     first = x.variables[0]

--- a/pycrunch/tests/test_insights.py
+++ b/pycrunch/tests/test_insights.py
@@ -1,0 +1,73 @@
+from unittest.mock import MagicMock
+
+from pycrunch.insights.variables_inspection import trace, InsightTimeline, inject_timeline
+
+
+def test_should_trace_something_to_timeline():
+    future_is_here = 1
+    trace(future_is_here=future_is_here)
+    trace(traced_variable=42)
+    pass
+
+def marker(name_of_the_marker):
+    pass
+
+def test_single_trace():
+    trace(value_a=1)
+
+
+def test_marker_single_variable_trace():
+    trace(value_a=1)
+    marker('point_of_interest')
+    trace(value_a=42)
+
+def test_marker_multiple_variables_trace():
+    for i in range(10):
+        trace(loop_counter=i)
+
+    trace(value_a=1)
+    marker('point_of_interest')
+    trace(value_a=42)
+    some_local = dict(
+        x=1,
+        y=2,
+        size=dict(
+            w=10,
+            h=10),
+        string='abc',
+    )
+    trace(some_local=some_local)
+
+
+def test_inject_timeline_and_call_it_on_trace():
+    future_is_here = 1
+    mock = MagicMock()
+    inject_timeline(mock)
+    trace(future_is_here=future_is_here)
+    mock.record.assert_called_with(future_is_here=future_is_here)
+    pass
+
+def test_timeline_one_variable():
+    variable_name = 42
+    x = InsightTimeline()
+
+    x.record(variable_name=42)
+
+    first = x.variables[0]
+    assert 'variable_name' == first.name
+    assert 42 == first.value
+
+
+def test_timeline_two_variables():
+    variable_a = 42
+    variable_b = 'Bret Victor'
+    x = InsightTimeline()
+
+    x.record(variable_a=variable_a, brightest_mind=variable_b)
+
+    first = x.variables[0]
+    second = x.variables[1]
+    assert 'variable_a' == first.name
+    assert 'brightest_mind' == second.name
+    assert 42 == first.value
+    assert variable_b == second.value

--- a/pycrunch/tests/test_insights_timeline.py
+++ b/pycrunch/tests/test_insights_timeline.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock
+
+from pycrunch.insights.variables_inspection import InsightTimeline
+
+
+def test_should_adjust_to_clock_start():
+    clock = MagicMock()
+    now_mock = MagicMock()
+    now_mock.side_effect = (100, 101, 110)
+
+    # 100 -- 101 ----------------- 110
+    # events should be in timeline time:
+    # 1 ----------------- 10
+    clock.now = now_mock
+    x = InsightTimeline(clock)
+    x.start()
+    x.record(x=1)
+    x.record(y=2)
+    variables = x.variables
+    assert variables[0].timestamp == 1
+    assert variables[1].timestamp == 10

--- a/pycrunch/tests/test_timeline_random.py
+++ b/pycrunch/tests/test_timeline_random.py
@@ -1,0 +1,10 @@
+from time import sleep
+from unittest.mock import MagicMock
+
+from pycrunch.insights.variables_inspection import InsightTimeline, trace
+
+
+def test_random_stuff():
+    for x in range(10):
+        # sleep(0.5)
+        trace(x=x)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 from distutils.core import setup
 
 setup(name='pycrunch-engine',
-      version='0.7.2',
+      version='0.9.0',
       description='Automatic Test Runner Engine',
       url='http://github.com/gleb-sevruk/pycrunch-engine',
       author='Gleb Sevruk',


### PR DESCRIPTION
This is a first step to support concepts described by Bret Victor on http://worrydream.com/LearnableProgramming/

This should improve Python testing experience by order of magnitude, especially in unknown codebases

Ideal view:
![image](https://user-images.githubusercontent.com/29545691/73035171-ec899700-3e4f-11ea-882f-8b5b6b8260ed.png)

![image](https://user-images.githubusercontent.com/29545691/73035196-f8755900-3e4f-11ea-9289-98fa6bfabb4a.png)
![image](https://user-images.githubusercontent.com/29545691/73035230-0c20bf80-3e50-11ea-821f-2f158fba9c9f.png)

![image](https://user-images.githubusercontent.com/29545691/73035241-15119100-3e50-11ea-8830-23e69a46a308.png)

![image](https://user-images.githubusercontent.com/29545691/73035247-1cd13580-3e50-11ea-86a0-aec49af27c67.png)

Current implementation:
![image](https://user-images.githubusercontent.com/29545691/73035361-70dc1a00-3e50-11ea-9a58-17e03f9ec5ea.png)

Double click to open variable snapshot value in new tab:
![image](https://user-images.githubusercontent.com/29545691/73035373-80f3f980-3e50-11ea-8d52-7f445bfd7925.png)

Multiple runs/variables at same time are supported

Download alpha build of connector plugiin

[pycrunch-intellij-connector-0.9.0-ALPHA.zip](https://github.com/gleb-sevruk/pycrunch-engine/files/4106270/pycrunch-intellij-connector-0.9.0-ALPHA.zip)


Other fixes :
Fixed issue when unittest lib might not be loaded