### PR TITLE
Release 1.0

### DIFF
--- a/pycrunch/api/serializers.py
+++ b/pycrunch/api/serializers.py
@@ -28,6 +28,13 @@ class CoverageRun:
 
 
     def parse_lines(self, cov):
+        """
+          Converts data from coverage.py format to internal format
+
+          This is candidate #1 for optimization as we do not use branch coverage
+          And plans are to integrate it with PyTrace Coverage
+          But then pytrace should be optimized/compiled for multi-platform
+        """
         output_file = io.StringIO()
         # todo: this should not exist, 0.3 seconds to run
         # self.percentage_covered = round(cov.report(file=output_file), 2)

--- a/pycrunch/api/shared.py
+++ b/pycrunch/api/shared.py
@@ -1,5 +1,4 @@
 from asyncio import shield
-# from pprint import pprint
 from time import perf_counter
 
 import socketio
@@ -15,6 +14,7 @@ async_mode='aiohttp'
 log_ws_internals = False
 sio = socketio.AsyncServer(async_mode=async_mode, cors_allowed_origins='*', logger=log_ws_internals, engineio_logger=log_ws_internals)
 timestamp = perf_counter
+
 
 class ExternalPipe:
     async def push(self, event_type, **kwargs):

--- a/pycrunch/api/shared.py
+++ b/pycrunch/api/shared.py
@@ -1,5 +1,5 @@
 from asyncio import shield
-from pprint import pprint
+# from pprint import pprint
 from time import perf_counter
 
 import socketio

--- a/pycrunch/api/socket_handlers.py
+++ b/pycrunch/api/socket_handlers.py
@@ -86,18 +86,22 @@ async def connect(sid, environ):
     global thread
     logger.debug('Client test_connected')
 
-    await pipe.push(event_type='connected', **{'data': 'Connected test_connected' })
+    await pipe.push(
+        event_type='connected',
+        **dict(
+            data='Connected test_connected',
+            engine_mode=engine.get_engine_mode(),
+            version=dict(
+                major=1,
+                minor=0,
+            )
+        )
+    )
     with thread_lock:
         if thread is None:
-            # thread = shared.socketio.start_background_task(target=dispather_thread, arg=42)
-            # pass
-            # thread = thread.start_new_thread(dispather_thread, args=42)
             thread = 1
             loop = asyncio.get_event_loop()
             loop.create_task(dispather_thread())
-            # thread = threading.Thread(target=dispather_thread)
-            # thread.start()
-            # thread.run()
 
 @shared.sio.event
 def disconnect(sid):

--- a/pycrunch/networking/protocol_state.py
+++ b/pycrunch/networking/protocol_state.py
@@ -19,6 +19,16 @@ class ProtocolState():
         self.current_payload_read_so_far = 0
 
     def feed(self, data):
+        """
+        This method is responsible for processing input datagrams
+        Message may be splitted across multiple datagrams
+
+        Here we read size of next packet from header with fixed byte-length
+          and accumulating multiple packages until entire message is read
+
+          also one datagram may contain multiple messages split by header
+          so this function solves all of these scenarios
+        """
         self.current_payload_size = len(data)
         # print(f'!!! GOT DATAGRAM, size: {self.current_payload_size}')
 

--- a/pycrunch/pipeline/abstract_task.py
+++ b/pycrunch/pipeline/abstract_task.py
@@ -1,7 +1,3 @@
-from datetime import datetime
-from queue import Queue
-import time
-
 class AbstractTask:
     def run(self):
         pass

--- a/pycrunch/pipeline/run_test_task.py
+++ b/pycrunch/pipeline/run_test_task.py
@@ -1,6 +1,6 @@
+import asyncio
 from pprint import pprint
 
-from pycrunch import session
 from pycrunch.api import shared
 from pycrunch.crossprocess.multiprocess_test_runner import MultiprocessTestRunner
 from pycrunch.introspection.history import execution_history
@@ -14,7 +14,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 class RunTestTask(AbstractTask):
-
     def __init__(self, tests):
         self.timestamp = shared.timestamp()
         self.tests = tests
@@ -32,19 +31,21 @@ class RunTestTask(AbstractTask):
             Here we run multiple tests at once using one or multiple processes
         """
         self.timeline.mark_event('run')
-
-        await engine.tests_will_run(self.tests)
+        async_tasks = [
+            engine.tests_will_run(self.tests)
+        ]
+        # await engine.tests_will_run(self.tests)
         converted_tests = list()
         for test in self.tests:
             converted_tests.append(dict(fqn=test.discovered_test.fqn, filename=test.discovered_test.filename,name=test.discovered_test.name, module=test.discovered_test.module, state='converted'))
 
         runner = MultiprocessTestRunner(timeout=30, timeline=self.timeline)
         self.timeline.mark_event('before running tests')
-        await runner.run(tests=converted_tests)
+        async_tasks.append(runner.run(tests=converted_tests))
+        # await runner.run(tests=converted_tests)
+        await asyncio.gather(*async_tasks)
         self.results = runner.results
-        # runner = TestRunner(runner_engine=runner_engine)
-        # with ModuleCleanup() as cleanup:
-        #     results = runner.run(self.tests)
+
         if self.results is not None:
             logger.debug('results are not none')
         if self.results is None:
@@ -54,7 +55,10 @@ class RunTestTask(AbstractTask):
         if not self.results:
             self.results = dict()
 
-        await engine.tests_did_run(self.results)
+        async_tasks_post = [
+            engine.tests_did_run(self.results)
+        ]
+        # await engine.tests_did_run(self.results)
 
         self.timeline.mark_event('Postprocessing: combined coverage, line hits, dependency tree')
         combined_coverage.add_multiple_results(self.results)
@@ -66,31 +70,43 @@ class RunTestTask(AbstractTask):
             results_as_json[k] = v.as_json()
 
         self.timeline.mark_event('Sending: test_run_completed event')
-
-        await shared.pipe.push(event_type='test_run_completed',
-                         coverage=dict(all_runs=results_as_json),
-                         # data=serialize_test_set_state(self.tests),
-                         timings=dict(start=self.timestamp, end=shared.timestamp()),
-                         ),
+        async_tasks_post.append(shared.pipe.push(event_type='test_run_completed',
+                                                 coverage=dict(all_runs=results_as_json),
+                                                 # data=serialize_test_set_state(self.tests),
+                                                 timings=dict(start=self.timestamp, end=shared.timestamp()),
+                                                 ))
+        # await shared.pipe.push(event_type='test_run_completed',
+        #                  coverage=dict(all_runs=results_as_json),
+        #                  # data=serialize_test_set_state(self.tests),
+        #                  timings=dict(start=self.timestamp, end=shared.timestamp()),
+        #                  ),
 
         self.timeline.mark_event('Started combined coverage serialization')
         serialized = serialize_combined_coverage(combined_coverage)
         self.timeline.mark_event('Completed combined coverage serialization')
 
-        self.timeline.mark_event('Send: combined coverage over WS')
-        await shared.pipe.push(event_type='combined_coverage_updated',
-                         combined_coverage=serialized,
-                         dependencies={entry_point: list(filenames) for entry_point, filenames in combined_coverage.dependencies.items() },
-                         aggregated_results=engine.all_tests.legacy_aggregated_statuses(),
-                         timings=dict(start=self.timestamp, end=shared.timestamp()),
-                         ),
+        self.timeline.mark_event('Sending: combined coverage over WS')
+        async_tasks_post.append(shared.pipe.push(event_type='combined_coverage_updated',
+                                                 combined_coverage=serialized,
+                                                 dependencies={entry_point: list(filenames) for entry_point, filenames in combined_coverage.dependencies.items() },
+                                                 aggregated_results=engine.all_tests.legacy_aggregated_statuses(),
+                                                 timings=dict(start=self.timestamp, end=shared.timestamp()),
+                                                 ))
+
+        self.timeline.mark_event('Waiting until post-processing tasks are completed')
+        await asyncio.gather(*async_tasks_post)
+
+        # await shared.pipe.push(event_type='combined_coverage_updated',
+        #                  combined_coverage=serialized,
+        #                  dependencies={entry_point: list(filenames) for entry_point, filenames in combined_coverage.dependencies.items() },
+        #                  aggregated_results=engine.all_tests.legacy_aggregated_statuses(),
+        #                  timings=dict(start=self.timestamp, end=shared.timestamp()),
+        #                  ),
 
         self.timeline.mark_event('Send: done, stopping timeline')
 
         self.timeline.stop()
         execution_history.save(self.timeline)
-
-        pass;
 
 
 # https://stackoverflow.com/questions/45369128/python-multithreading-queue

--- a/pycrunch/pipeline/run_test_task.py
+++ b/pycrunch/pipeline/run_test_task.py
@@ -28,6 +28,9 @@ class RunTestTask(AbstractTask):
         self.results = results
 
     async def run(self):
+        """
+            Here we run multiple tests at once using one or multiple processes
+        """
         self.timeline.mark_event('run')
 
         await engine.tests_will_run(self.tests)

--- a/pycrunch/plugins/django_support/django_runner_engine.py
+++ b/pycrunch/plugins/django_support/django_runner_engine.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 class DjangoRunnerEngine(_abstract_runner.Runner):
     def __init__(self):
         config.prepare_django()
-        pass
 
     def run_test(self, test) -> ExecutionResult:
         # import django

--- a/pycrunch/plugins/simple/simple_runner_engine.py
+++ b/pycrunch/plugins/simple/simple_runner_engine.py
@@ -10,6 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 class SimpleTestRunnerEngine(_abstract_runner.Runner):
+    """
+      This class probably is not used anymore. It was for early prototype.
+    """
     def run_test(self, test) -> ExecutionResult:
         execution_result = ExecutionResult()
         try:

--- a/pycrunch/scheduling/client_protocol.py
+++ b/pycrunch/scheduling/client_protocol.py
@@ -30,6 +30,7 @@ class EchoClientProtocol(asyncio.Protocol):
         counter += 1
 
     def connection_made(self, transport):
+        self.timeline.mark_event(f'TCP: Connection established...')
         self.transport = transport
         msg = HandshakeMessage(self.task_id)
         msg_bites = pickle.dumps(msg)
@@ -48,7 +49,6 @@ class EchoClientProtocol(asyncio.Protocol):
             timeline.mark_event(f'TCP: Received tests to run; id: {msg.task.id}')
 
             runner_engine = None
-            # add root of django project
 
             timeline.mark_event('Deciding on runner engine...')
 
@@ -83,8 +83,7 @@ class EchoClientProtocol(asyncio.Protocol):
                 timeline.mark_event('Run: exception during execution')
 
             timeline.stop()
-            # timeline.to_console()
-            # time.sleep(0.01)
+
             msg = TestRunTimingsMessage(timeline)
             bytes_to_send1 = pickle.dumps(msg)
             # xxx = bytearray(12345678)
@@ -118,7 +117,8 @@ class EchoClientProtocol(asyncio.Protocol):
         self.send_with_header(bytes_to_send)
 
     def connection_lost(self, exc):
-        print(f'[{self.task_id}]The connection to server closed')
+        self.timeline.mark_event(f'TCP: Connection to server lost')
+        # print(f'[{self.task_id}]The connection to server closed')
         self.on_con_lost.set_result(True)
 
     def error_received(self, exc):

--- a/pycrunch/scheduling/client_protocol.py
+++ b/pycrunch/scheduling/client_protocol.py
@@ -10,7 +10,15 @@ counter = 0
 
 
 class EchoClientProtocol(asyncio.Protocol):
-
+    """
+    This class represents multiprocess-child connection client protocol
+    Supported input actions are
+       - test-run-task
+    Output messages:
+       - test_run_results
+       - timings
+       - close [asks server to close connection so child process can terminate]
+    """
     def __init__(self, on_connection_lost, task_id, timeline, engine_to_use):
         self.engine_to_use = engine_to_use
         self.timeline = timeline
@@ -31,7 +39,6 @@ class EchoClientProtocol(asyncio.Protocol):
 
 
     def data_received(self, data):
-        # asyncio.sleep(2)
         msg = pickle.loads(data)
         if msg.kind == 'test-run-task':
             # import pydevd_pycharm

--- a/pycrunch/scheduling/scheduler.py
+++ b/pycrunch/scheduling/scheduler.py
@@ -49,6 +49,6 @@ class TestRunScheduler():
             spliced = tests[from_index:to_index]
             logger.debug(f'core {x}; spliced amount: {len(spliced)}')
             plan = TestRunPlan(spliced)
-            list_of_tasks.append(TestRunPlan(spliced))
+            list_of_tasks.append(plan)
             tests_so_far += tests_to_run_on_single_core
         return list_of_tasks

--- a/pycrunch/scheduling/server_protocol.py
+++ b/pycrunch/scheduling/server_protocol.py
@@ -71,6 +71,7 @@ class TestRunnerServerProtocol(asyncio.Protocol):
             self.timeline.mark_event('TCP: Got timings from subprocess')
             execution_history.save(msg.timeline)
         if msg.kind == 'close':
+            self.timeline.mark_event('TCP: Received close message')
             logger.debug('Close the client socket')
             self.transport.close()
             self.completion_future.set_result(self.results)

--- a/pycrunch/session/auto_configuration.py
+++ b/pycrunch/session/auto_configuration.py
@@ -1,0 +1,24 @@
+import io
+from pathlib import Path
+
+class AutoConfiguration:
+    def __init__(self, configuration_file):
+        """
+        :type configuration_file: Path
+        """
+        self.configuration_file = configuration_file
+
+    def ensure_configuration_exist(self):
+        if self.configuration_file.exists():
+            return
+        
+        self.create_default_configuration_file()
+
+    def create_default_configuration_file(self):
+        default_config_file = '''# documentation https://pycrunch.com/docs/configuration-file
+engine:
+    runtime: pytest'''
+        with io.open(self.configuration_file, encoding='utf-8', mode='w') as f:
+            f.write(default_config_file)
+
+        print(f'Created default configuration file.')

--- a/pycrunch/session/configuration.py
+++ b/pycrunch/session/configuration.py
@@ -6,6 +6,8 @@ import logging
 
 import yaml
 
+from pycrunch.session.auto_configuration import AutoConfiguration
+
 logger = logging.getLogger(__name__)
 
 
@@ -72,8 +74,13 @@ class Configuration:
         self.engine_directory = engine_directory
 
     def load_runtime_configuration(self):
+        # This will output exact location of config file
         print(str(self.configuration_file_path().absolute()))
         print(self.configuration_file_path())
+
+        auto_config = AutoConfiguration(self.configuration_file_path())
+        auto_config.ensure_configuration_exist()
+
         try:
             with io.open(self.configuration_file_path(), encoding='utf-8') as f:
                 x = yaml.safe_load(f)
@@ -88,16 +95,12 @@ class Configuration:
                     runtime_engine_name = engine_config.get('runtime', None)
                     if runtime_engine_name:
                         self.runtime_engine_will_change(runtime_engine_name)
-                    runtime_mode = engine_config.get('mode', None)
-                    if runtime_mode:
-                        self.runtime_mode_will_change(runtime_mode)
                     cpu_cores = engine_config.get('cpu-cores', None)
                     if cpu_cores:
                         self.cpu_cores_will_change(cpu_cores)
                     multiprocess_threshold = engine_config.get('multiprocessing-threshold', None)
                     if multiprocess_threshold:
                         self.multiprocess_threshold_will_change(multiprocess_threshold)
-
 
                 pinned_tests = x.get('pinned-tests', None)
                 if pinned_tests:
@@ -132,11 +135,9 @@ class Configuration:
         with io.open(self.configuration_file_path(), encoding='utf-8', mode='r') as f:
             existing_config = yaml.safe_load(f)
 
-
         existing_config['pinned-tests'] = list(fqns)
         with io.open(self.configuration_file_path(), encoding='utf-8', mode='w') as f:
             yaml.dump(existing_config, f, default_flow_style=False)
-        pass
 
     def is_test_pinned(self, fqn):
         return fqn in self.pinned_tests

--- a/pycrunch/session/state.py
+++ b/pycrunch/session/state.py
@@ -99,6 +99,9 @@ class EngineState:
     def engine_mode_will_change(self, new_mode):
         config.runtime_mode_will_change(new_mode)
 
+    def get_engine_mode(self):
+        return config.engine_mode
+
     def prepare_runtime_configuration_if_necessary(self):
         if not self.runtime_configuration_ready:
             self.runtime_configuration_ready = True

--- a/pycrunch/tests/test_auto_configuration.py
+++ b/pycrunch/tests/test_auto_configuration.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest import mock
+from unittest.mock import Mock, mock_open
+
+from pycrunch.session.auto_configuration import AutoConfiguration
+
+
+class TestAutoConfigDecision(unittest.TestCase):
+    def setUp(self):
+        self.config_file_mock = Mock()
+        self.create_function_mock = Mock()
+
+    def test_if_config_exists_do_not_create_new(self):
+        self.when_configuration_file_already_on_disk()
+        sut = self.create_sut()
+
+        sut.ensure_configuration_exist()
+
+        self.create_function_mock.assert_not_called()
+
+    def test_if_no_config_should_call_create_default(self):
+        self.when_file_does_not_exist()
+        sut = self.create_sut()
+
+        sut.ensure_configuration_exist()
+
+        self.create_function_mock.assert_called_once()
+
+    def create_sut(self):
+        sut = AutoConfiguration(self.config_file_mock)
+        sut.create_default_configuration_file = self.create_function_mock
+        return sut
+
+    def when_file_does_not_exist(self):
+        self.set_config_file_existence(False)
+
+    def when_configuration_file_already_on_disk(self):
+        self.set_config_file_existence(True)
+
+    def set_config_file_existence(self, val):
+        self.config_file_mock.exists.return_value = val
+
+
+class TestAutoConfigCreation(unittest.TestCase):
+    def setUp(self):
+        self.config_file_mock = Mock()
+        self.create_function_mock = Mock()
+
+    def test_writes_to_file_at_path(self):
+        mocked_open = mock_open()
+        with mock.patch('io.open', mocked_open) as io_mock:
+            sut = AutoConfiguration(self.config_file_mock)
+            sut.create_default_configuration_file()
+            handle = io_mock()
+            default_config_file = '''# documentation https://pycrunch.com/docs/configuration-file
+engine:
+    runtime: pytest'''
+            handle.write.assert_called_once_with(default_config_file)
+

--- a/pycrunch/tests/test_modules_cleanup.py
+++ b/pycrunch/tests/test_modules_cleanup.py
@@ -1,2 +1,2 @@
 def test_nested():
-    print('hello nested2')
+    print('hello neste2')

--- a/pycrunch/tests/tests_configuration.py
+++ b/pycrunch/tests/tests_configuration.py
@@ -1,6 +1,6 @@
 from _pydecimal import DecimalException
 from unittest import mock
-from unittest.mock import mock_open
+from unittest.mock import mock_open, patch, Mock
 
 import pytest
 
@@ -27,21 +27,27 @@ def test_can_change_to_django_engine():
 def create_sut():
     return session.configuration.Configuration()
 
+def test_should_call_auto_config():
+    with patch('pycrunch.session.configuration.AutoConfiguration.ensure_configuration_exist') as auto:
+        sut = create_sut()
+        sut.load_runtime_configuration()
+        auto.assert_called_once()
 
 def test_non_supported_engine_throws():
     import pytest
     sut = create_sut()
     with pytest.raises(Exception):
-        sut.runtime_engine_will_change('n-s')
+        sut.runtime_engine_will_change('not-supported')
 
 read_data = '''
+engine:
+  runtime: simple
 discovery:
   exclusions:
    - directory_1
    - directory_2
-engine:
-  runtime: simple
-  mode: manual
+mode: manual
+
 '''
 def test_exclusion_list():
     with mock.patch('io.open', mock_open(read_data=read_data)) as x:
@@ -50,12 +56,6 @@ def test_exclusion_list():
         assert 'directory_1' in sut.discovery_exclusions
         assert 'directory_2' in sut.discovery_exclusions
         assert 'directory_3' not in sut.discovery_exclusions
-
-def test_engine_mode():
-    with mock.patch('io.open', mock_open(read_data=read_data)) as x:
-        sut = create_sut()
-        sut.load_runtime_configuration()
-        assert sut.engine_mode == 'manual'
 
 def test_engine_mode_auto_by_default():
     sut = create_sut()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 coverage==4.5.3
-pytest==4.6.3
+
+# last know working 5.4.3
+pytest
 watchgod
 python-socketio
 aiohttp

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='pycrunch-engine',
           'console_scripts': ['pycrunch-engine=pycrunch.main:run'],
       },
       install_requires=[
-          'pytest==4.6.3',
+          'pytest',
           'coverage==4.5.3',
           'PyYAML',
           'watchgod',


### PR DESCRIPTION
1. Removed pytest 4.5 pinned version (as asked in https://github.com/gleb-sevruk/pycrunch-engine/pull/14)
2. Automatically create configuration file on the first run.
3. Added support for version exchange during WebSocket connection from JetBrains IDE (can be used in future to force-update plugin or pip package

Minor code cleanup and documentation

This release will be backward and forward compatible with 1.0 version of pycrunch-intelij-connector