### PR TITLE
Upgrade coverage to 5.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-coverage==4.5.3
+coverage==5.5
 
 # last know working 5.4.3
 pytest

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 from distutils.core import setup
 
 setup(name='pycrunch-engine',
-      version='1.2.2',
+      version='1.2.3',
       description='Automatic Test Runner Engine',
       url='http://github.com/gleb-sevruk/pycrunch-engine',
       author='Gleb Sevruk',
@@ -17,7 +17,7 @@ setup(name='pycrunch-engine',
       },
       install_requires=[
           'pytest',
-          'coverage==4.5.3',
+          'coverage==5.5',
           'PyYAML',
           'watchgod',
           'python-socketio>=4,<5',


### PR DESCRIPTION
coverage 4.5.3 has been obsoleted and it will conflict on installing new version of pytest-cov.