### PR TITLE
Add `ast.AsyncFunctionDef` to correctly recognize async test methods.

### DIFF
--- a/pycrunch/discovery/ast_discovery.py
+++ b/pycrunch/discovery/ast_discovery.py
@@ -95,7 +95,7 @@ class AstTestDiscovery:
     def load_tests_from_ast_representation(self, ast_tree: ast.Module) -> List[str]:
         results = []
 
-        def process_function_def(func: ast.FunctionDef) -> List[str]:
+        def process_function_def(func: ast.FunctionDef | ast.AsyncFunctionDef) -> List[str]:
             if self.looks_like_test_name(func.name):
                 return [func.name]
 
@@ -112,14 +112,15 @@ class AstTestDiscovery:
             if c2:
                 for member in class_ast.body:
                     # TODO nested classes
-                    if type(member) != ast.FunctionDef:
+                    if not isinstance(member, ast.FunctionDef | ast.AsyncFunctionDef):
                         continue
-                    member: ast.FunctionDef
+                    member: ast.FunctionDef | ast.AsyncFunctionDef
                     if self.looks_like_test_name(member.name):
                         class_results.append(f"{class_ast_name}::{member.name}")
             return class_results
 
         mapping = {
+            ast.AsyncFunctionDef: process_function_def,
             ast.FunctionDef: process_function_def,
             ast.ClassDef: process_class_def,
         }


### PR DESCRIPTION
- Added `ast.AsyncFunctionDef` to discovery
- Tested on my own code, while existing tests pass (other than the 5 failing ones that happened on fork)

Resolves #62 