### PR TITLE
README.md - add info about exclusions format on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Most of the parameters listed:
 discovery:
   # Paths, that will be excluded during test discovery.
   # The file will be excluded from discovery, if either starts_with or ends_with condition is true on filename. File path is relative to project root folder.
+  # On Windows, use `\` separator when excluding paths
   exclusions:
   - front/
   - venv/


### PR DESCRIPTION
I encountered an issue trying to run pycrunch on Windows, turns out excluded paths need to use `\` instead of `/` as a separator (See: https://github.com/gleb-sevruk/pycrunch-engine/issues/80) 
I thought it would be good to mention it in the readme. 