### PR TITLE
Prefixes will be respected for discovery using AST tree;

### DIFF
--- a/.pycrunch-config.yaml
+++ b/.pycrunch-config.yaml
@@ -15,6 +15,8 @@ engine:
   change-detection-root: .
 #   requires restart
   enable-web-ui: true
+  module-prefixes: spec
+  function-prefixes: should must
 env:
   DJANGO_SETTINGS_MODULE: somedjangoapp.settings.local
 pinned-tests:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ engine:
 
   # Enable web UI (Default - `false`)
   enable-web-ui: true
+  
+  # Customize pytest.ini  [spec_file.py -> def should_be_true()]
+  # python_files = test_*.py tests_*.py spec*.py moduletest*.py
+  module-prefixes: test spec moduletest
+  # python_functions = *_test should* must*
+  function-prefixes: should must
 
 # Environment variables to forward to pytest executors
 env:

--- a/pycrunch/discovery/ast_discovery.py
+++ b/pycrunch/discovery/ast_discovery.py
@@ -166,10 +166,11 @@ class AstTestDiscovery:
         return module_short_name.startswith((
             'test_',
             'tests_',
+            *self.configuration.module_prefixes,
         )) or module_short_name.endswith(('_test', 'tests', '_tests'))
 
     def looks_like_test_name(self, v):
-        return v.startswith('test_') or v.endswith('_test')
+        return any(v.startswith(prefix) for prefix in ['test_', *self.configuration.function_prefixes]) or v.endswith('_test')
 
     def looks_like_test_class(self, name: str) -> bool:
         return name.startswith('Test') or name.endswith('Test')

--- a/pycrunch/discovery/ast_discovery.py
+++ b/pycrunch/discovery/ast_discovery.py
@@ -170,7 +170,10 @@ class AstTestDiscovery:
         )) or module_short_name.endswith(('_test', 'tests', '_tests'))
 
     def looks_like_test_name(self, v):
-        return any(v.startswith(prefix) for prefix in ['test_', *self.configuration.function_prefixes]) or v.endswith('_test')
+        return any(
+            v.startswith(prefix)
+            for prefix in ['test_', *self.configuration.function_prefixes]
+        ) or v.endswith('_test')
 
     def looks_like_test_class(self, name: str) -> bool:
         return name.startswith('Test') or name.endswith('Test')

--- a/pycrunch_tests/tests_ast_discovery.py
+++ b/pycrunch_tests/tests_ast_discovery.py
@@ -32,6 +32,16 @@ def test_double_inheritance():
     assert 'DoublyInheritedScenario::test_1' in test_names
 
 
+def test_custom_module_prefix():
+    configuration = Configuration()
+    configuration.module_prefixes = 'spec'
+    configuration.function_prefixes = 'should'
+    actual = run_dogfood_discovery(config=configuration)
+    test_names = list(map(lambda _: _.name, actual.tests))
+
+    assert 'should_regular_2' in test_names
+
+
 def test_only_methods_are_discovered_not_variables():
     actual = run_dogfood_discovery()
     test_names = list(map(lambda _: _.name, actual.tests))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
-python_files = test_*.py tests_*.py
+python_files = test_*.py tests_*.py spec*.py
+python_functions = *_test should_*
+
 # This tests should be run separately, not inside unit testing suite
 norecursedirs = integration_tests/*
 # exclude_from_default_run - This tests are failing on purpose.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
-python_files = test_*.py tests_*.py spec*.py
-python_functions = *_test should_*
+python_files = test_*.py tests_*.py spec*.py *_test.py
+python_functions = test_* *_test should_*
 
 # This tests should be run separately, not inside unit testing suite
 norecursedirs = integration_tests/*


### PR DESCRIPTION
Continuation of
https://github.com/gleb-sevruk/pycrunch-engine/pull/116

I forgot that simple test discovery is not used anymore. Instead fixed for ast